### PR TITLE
added Joblib Parallelization

### DIFF
--- a/pymoo/core/problem.py
+++ b/pymoo/core/problem.py
@@ -57,12 +57,13 @@ class DaskParallelization:
         state.pop("client", None)
         return state
 
+
 class JoblibParallelization:
 
-    def __init__(self, parallel, delayed, *args, **kwargs) -> None:
+    def __init__(self, aJoblibParallel,  aJoblibDelayed, *args, **kwargs) -> None:
         super().__init__()
-        self.parallel = parallel # joblib runner object
-        self.delayed = delayed # delayed function 
+        self.parallel = aJoblibParallel 
+        self.delayed =  aJoblibDelayed 
 
     def __call__(self, f, X):
         return self.parallel(self.delayed(f)(x) for x in X)
@@ -72,6 +73,7 @@ class JoblibParallelization:
         state.pop("parallel", None)
         state.pop("delayed", None)
         return state
+
 
 class Problem:
     def __init__(self,

--- a/pymoo/core/problem.py
+++ b/pymoo/core/problem.py
@@ -57,6 +57,21 @@ class DaskParallelization:
         state.pop("client", None)
         return state
 
+class JoblibParallelization:
+
+    def __init__(self, parallel, delayed, *args, **kwargs) -> None:
+        super().__init__()
+        self.parallel = parallel # joblib runner object
+        self.delayed = delayed # delayed function 
+
+    def __call__(self, f, X):
+        return self.parallel(self.delayed(f)(x) for x in X)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop("parallel", None)
+        state.pop("delayed", None)
+        return state
 
 class Problem:
     def __init__(self,


### PR DESCRIPTION
The usage is similar to the usage of Starmap e.g. Dask for Threads this looks like: 

    from pymoo.algorithms.soo.nonconvex.ga import GA
    from pymoo.optimize import minimize
    from pymoo.core.problem import JoblibParallelization
    from joblib import Parallel , delayed

    # initialize the thread pool and create the runner
    
    n_threads = 4
    pool = Parallel(n_jobs= n_threads , prefer= "threads")
    runner = JoblibParallelization(parallel= pool, delayed= delayed)

    # define the problem by passing the joblib object
    problem = MyProblem(elementwise_runner=runner)

    res = minimize(problem, GA(), termination=("n_gen", 200), seed=1)
    print('Threads:', res.exec_time)

And for Processes:
    
    from pymoo.algorithms.soo.nonconvex.ga import GA
    from pymoo.optimize import minimize
    from pymoo.core.problem import JoblibParallelization
    from joblib import Parallel , delayed

    # initialize the processes pool and create the runner
    
    n_processes = 4
    pool = Parallel(n_jobs= n_processes , prefer= "processes")
    runner = JoblibParallelization(parallel= pool, delayed= delayed)

    # define the problem by passing the joblib object
    problem = MyProblem(elementwise_runner=runner)

    res = minimize(problem, GA(), termination=("n_gen", 200), seed=1)
    print('Threads:', res.exec_time)